### PR TITLE
Optional cacertfile

### DIFF
--- a/lib/poxa.ex
+++ b/lib/poxa.ex
@@ -57,7 +57,7 @@ defmodule Poxa do
           ssl_port = Keyword.get(ssl_config, :port)
           Lager.info "Starting Poxa using SSL on port #{ssl_port}"
         else
-          Lager.error "Please specify port, certfile and keyfile"
+          Lager.error "Must specify port, certfile and keyfile (cacertfile optional)"
         end
       :undefined -> Lager.info "SSL not configured/started"
     end


### PR DESCRIPTION
Should cacertfile be optional for poxa?  It seems to be optional for cowboy:

https://github.com/smarkets/cowboy/blob/26cb10ba3a14bac3f502c6dfaecc7c73ab31880a/src/cowboy_ssl_transport.erl#L53
