### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,11 @@ Pusher.port   = 8080
 ```
 And pusher-js:
 ```javascript
-Pusher.host    = 'localhost'
-Pusher.ws_port = 8080
 
 // will only use WebSockets
 var pusher = new Pusher(API_KEY, {
+  wsHost: 'localhost',
+  wsPort: 8080,
   enabledTransports: ["ws", "flash"],
   disabledTransports: ["flash"]
 });


### PR DESCRIPTION
[Use option parameter](https://github.com/pusher/pusher-js#wshost-wsport-wssport-httphost-httpport-httpsport) instead of global config([it's deprecated](https://pusher.com/docs/client_api_guide/client_global_configuration))
