### PR TITLE
Add filter_by_prefix support to /channels

### DIFF
--- a/lib/poxa/channel.ex
+++ b/lib/poxa/channel.ex
@@ -47,6 +47,7 @@ defmodule Poxa.Channel do
   iex> Poxa.Channel.matches("foo-bar", "bar-")
   false
   """
+  def matches?(channel, ""), do: false
   def matches?(channel, prefix) do
     base = byte_size(prefix)
     <<match :: binary-size(base), _ :: binary>> = channel

--- a/lib/poxa/channel.ex
+++ b/lib/poxa/channel.ex
@@ -40,6 +40,20 @@ defmodule Poxa.Channel do
   end
 
   @doc """
+  Returns true if prefix matches channel
+
+  iex> Poxa.Channel.matches?("foo-bar", "foo-")
+  true
+  iex> Poxa.Channel.matches("foo-bar", "bar-")
+  false
+  """
+  def matches?(channel, prefix) do
+    base = byte_size(prefix)
+    <<match :: binary-size(base), _ :: binary>> = channel
+    match == prefix
+  end
+
+  @doc """
   Returns true if the channel has at least 1 subscription
   """
   @spec occupied?(binary) :: boolean

--- a/lib/poxa/channel.ex
+++ b/lib/poxa/channel.ex
@@ -44,10 +44,12 @@ defmodule Poxa.Channel do
 
   iex> Poxa.Channel.matches?("foo-bar", "foo-")
   true
-  iex> Poxa.Channel.matches("foo-bar", "bar-")
+  iex> Poxa.Channel.matches?("foo-bar", "bar-")
+  false
+  iex> Poxa.Channel.matches?("foo-bar", "")
   false
   """
-  def matches?(channel, ""), do: false
+  def matches?(_, ""), do: false
   def matches?(channel, prefix) do
     base = byte_size(prefix)
     <<match :: binary-size(base), _ :: binary>> = channel

--- a/lib/poxa/channel.ex
+++ b/lib/poxa/channel.ex
@@ -48,12 +48,16 @@ defmodule Poxa.Channel do
   false
   iex> Poxa.Channel.matches?("foo-bar", "")
   false
+  iex> Poxa.Channel.matches?("foo-bar", "foo-bartman")
+  false
   """
   def matches?(_, ""), do: false
   def matches?(channel, prefix) do
     base = byte_size(prefix)
-    <<match :: binary-size(base), _ :: binary>> = channel
-    match == prefix
+    case channel do
+      <<^prefix :: binary-size(base), _ :: binary>> -> true
+      _ -> false
+    end
   end
 
   @doc """

--- a/lib/poxa/channels_handler.ex
+++ b/lib/poxa/channels_handler.ex
@@ -22,7 +22,7 @@ defmodule Poxa.ChannelsHandler do
   def malformed_request(req, _state) do
     {info, req} = :cowboy_req.qs_val("info", req, "")
     attributes = String.split(info, ",")
-      |> Enum.reject(fn s -> s == "" end)
+      |> Enum.reject(&(&1 == ""))
     {channel, req} = :cowboy_req.binding(:channel_name, req, nil)
     if channel do
       {malformed_request_one_channel?(attributes, channel), req, {:one, channel, attributes}}

--- a/lib/poxa/channels_handler.ex
+++ b/lib/poxa/channels_handler.ex
@@ -94,14 +94,9 @@ defmodule Poxa.ChannelsHandler do
   end
 
   defp channels(filter, attributes) do
-    Channel.all
-      |> Enum.filter_map(
-        fn channel ->
-          filter_channel(channel, filter)
-        end,
-        fn channel ->
-          {channel, mount_attribute_list(attributes, channel)}
-        end)
+    for channel <- Channel.all, filter_channel(channel, filter) do
+      {channel, mount_attribute_list(attributes, channel)}
+    end
   end
 
   defp filter_channel(channel, nil), do: !Channel.private?(channel)

--- a/test/channels_handler_test.exs
+++ b/test/channels_handler_test.exs
@@ -12,11 +12,47 @@ defmodule Poxa.ChannelsHandlerTest do
     :ok
   end
 
-  test "malformed_request on multiple channels" do
-    expect(:cowboy_req, :qs_val, 3, {"subscription_count", :req})
+  test "malformed_request on multiple channels with no attributes" do
+    expect(:cowboy_req, :qs_val, 3, seq([{"", :req}, {nil, :req}]))
     expect(:cowboy_req, :binding, 3, {nil, :req})
 
-    assert malformed_request(:req, :state) == {false, :req, nil}
+    assert malformed_request(:req, :state) == {false, :req, {:all, nil, []}}
+
+    assert validate :cowboy_req
+  end
+
+  test "malformed_request on multiple channels with valid attributes" do
+    expect(:cowboy_req, :qs_val, 3, seq([{"subscription_count", :req}, {nil, :req}]))
+    expect(:cowboy_req, :binding, 3, {nil, :req})
+
+    assert malformed_request(:req, :state) == {false, :req, {:all, nil, ["subscription_count"]}}
+
+    assert validate :cowboy_req
+  end
+
+  test "malformed_request on multiple channels with invalid attributes" do
+    expect(:cowboy_req, :qs_val, 3, seq([{"user_count", :req}, {nil, :req}]))
+    expect(:cowboy_req, :binding, 3, {nil, :req})
+
+    assert malformed_request(:req, :state) == {true, :req, {:all, nil, ["user_count"]}}
+
+    assert validate :cowboy_req
+  end
+
+  test "malformed_request on multiple channels with filter" do
+    expect(:cowboy_req, :qs_val, 3, seq([{"", :req}, {"poxa-", :req}]))
+    expect(:cowboy_req, :binding, 3, {nil, :req})
+
+    assert malformed_request(:req, :state) == {false, :req, {:all, "poxa-", []}}
+
+    assert validate :cowboy_req
+  end
+
+  test "malformed_request on multiple channels with presence filter and user_count attribute" do
+    expect(:cowboy_req, :qs_val, 3, seq([{"user_count", :req}, {"presence-", :req}]))
+    expect(:cowboy_req, :binding, 3, {nil, :req})
+
+    assert malformed_request(:req, :state) == {false, :req, {:all, "presence-", ["user_count"]}}
 
     assert validate :cowboy_req
   end
@@ -25,7 +61,7 @@ defmodule Poxa.ChannelsHandlerTest do
     expect(:cowboy_req, :qs_val, 3, {"subscription_count,message_count", :req})
     expect(:cowboy_req, :binding, 3, {"channel", :req})
 
-    assert malformed_request(:req, :state) == {true, :req, {"channel", ["subscription_count", "message_count"]}}
+    assert malformed_request(:req, :state) == {true, :req, {:one, "channel", ["subscription_count", "message_count"]}}
 
     assert validate :cowboy_req
   end
@@ -34,7 +70,7 @@ defmodule Poxa.ChannelsHandlerTest do
     expect(:cowboy_req, :qs_val, 3, {"message_count", :req})
     expect(:cowboy_req, :binding, 3, {"channel", :req})
 
-    assert malformed_request(:req, :state) == {true, :req, {"channel", ["message_count"]}}
+    assert malformed_request(:req, :state) == {true, :req, {:one, "channel", ["message_count"]}}
 
     assert validate :cowboy_req
   end
@@ -43,7 +79,7 @@ defmodule Poxa.ChannelsHandlerTest do
     expect(:cowboy_req, :qs_val, 3, {"subscription_count", :req})
     expect(:cowboy_req, :binding, 3, {"channel", :req})
 
-    assert malformed_request(:req, :state) == {false, :req, {"channel", ["subscription_count"]}}
+    assert malformed_request(:req, :state) == {false, :req, {:one, "channel", ["subscription_count"]}}
 
     assert validate :cowboy_req
   end
@@ -52,7 +88,7 @@ defmodule Poxa.ChannelsHandlerTest do
     expect(:cowboy_req, :qs_val, 3, {"user_count", :req})
     expect(:cowboy_req, :binding, 3, {"channel", :req})
 
-    assert malformed_request(:req, :state) == {true, :req, {"channel", ["user_count"]}}
+    assert malformed_request(:req, :state) == {true, :req, {:one, "channel", ["user_count"]}}
 
     assert validate :cowboy_req
   end
@@ -61,7 +97,7 @@ defmodule Poxa.ChannelsHandlerTest do
     expect(:cowboy_req, :qs_val, 3, {"user_count,subscription_count", :req})
     expect(:cowboy_req, :binding, 3, {"presence-channel", :req})
 
-    assert malformed_request(:req, :state) == {false, :req, {"presence-channel", ["user_count", "subscription_count"]}}
+    assert malformed_request(:req, :state) == {false, :req, {:one, "presence-channel", ["user_count", "subscription_count"]}}
 
     assert validate :cowboy_req
   end
@@ -72,7 +108,7 @@ defmodule Poxa.ChannelsHandlerTest do
     expected = [occupied: true, subscription_count: 5]
     expect(JSEX, :encode!, [{[expected], :encoded_json}])
 
-    assert get_json(:req, {:channel, ["subscription_count"]}) == {:encoded_json, :req, nil}
+    assert get_json(:req, {:one, :channel, ["subscription_count"]}) == {:encoded_json, :req, nil}
 
     assert validate JSEX
     assert validate Channel
@@ -84,7 +120,7 @@ defmodule Poxa.ChannelsHandlerTest do
     expected = [occupied: true, user_count: 3]
     expect(JSEX, :encode!, [{[expected], :encoded_json}])
 
-    assert get_json(:req, {:channel, ["user_count"]}) == {:encoded_json, :req, nil}
+    assert get_json(:req, {:one, :channel, ["user_count"]}) == {:encoded_json, :req, nil}
 
     assert validate JSEX
     assert validate Channel
@@ -98,7 +134,7 @@ defmodule Poxa.ChannelsHandlerTest do
     expected = [occupied: true, subscription_count: 5, user_count: 3]
     expect(JSEX, :encode!, [{[expected], :encoded_json}])
 
-    assert get_json(:req, {:channel, ["subscription_count", "user_count"]}) == {:encoded_json, :req, nil}
+    assert get_json(:req, {:one, :channel, ["subscription_count", "user_count"]}) == {:encoded_json, :req, nil}
 
     assert validate JSEX
     assert validate Channel
@@ -113,7 +149,7 @@ defmodule Poxa.ChannelsHandlerTest do
     expected = [channels: [{"presence-channel", user_count: 3}]]
     expect(JSEX, :encode!, [{[expected], :encoded_json}])
 
-    assert get_json(:req, nil) == {:encoded_json, :req, nil}
+    assert get_json(:req, {:all, nil, ["user_count"]}) == {:encoded_json, :req, nil}
 
     assert validate JSEX
     assert validate Channel
@@ -121,14 +157,12 @@ defmodule Poxa.ChannelsHandlerTest do
   end
 
   test "get_json on every single channel with filter" do
-    expect(:cowboy_req, :qs_val, 3, {"poxa-", :req})
     expect(Channel, :all, 0, ["presence-channel", "poxa-channel"])
-    expect(Channel, :presence?, 1, false)
-    expect(Channel, :subscription_count, 1, 9)
-    expected = [channels: [{"poxa-channel", user_count: 9}]]
+    expect(Channel, :matches?, 2, seq([false, true]))
+    expected = [channels: [{"poxa-channel", []}]]
     expect(JSEX, :encode!, [{[expected], :encoded_json}])
 
-    assert get_json(:req, nil) == {:encoded_json, :req, nil}
+    assert get_json(:req, {:all, 'poxa-', []}) == {:encoded_json, :req, nil}
 
     assert validate JSEX
     assert validate Channel

--- a/test/channels_handler_test.exs
+++ b/test/channels_handler_test.exs
@@ -106,7 +106,9 @@ defmodule Poxa.ChannelsHandlerTest do
   end
 
   test "get_json on every single channel" do
+    expect(:cowboy_req, :qs_val, 3, {nil, :req})
     expect(Channel, :all, 0, ["presence-channel", "private-channel"])
+    expect(Channel, :presence?, 1, true)
     expect(PresenceChannel, :user_count, 1, 3)
     expected = [channels: [{"presence-channel", user_count: 3}]]
     expect(JSEX, :encode!, [{[expected], :encoded_json}])
@@ -116,5 +118,19 @@ defmodule Poxa.ChannelsHandlerTest do
     assert validate JSEX
     assert validate Channel
     assert validate PresenceChannel
+  end
+
+  test "get_json on every single channel with filter" do
+    expect(:cowboy_req, :qs_val, 3, {"poxa-", :req})
+    expect(Channel, :all, 0, ["presence-channel", "poxa-channel"])
+    expect(Channel, :presence?, 1, false)
+    expect(Channel, :subscription_count, 1, 9)
+    expected = [channels: [{"poxa-channel", user_count: 9}]]
+    expect(JSEX, :encode!, [{[expected], :encoded_json}])
+
+    assert get_json(:req, nil) == {:encoded_json, :req, nil}
+
+    assert validate JSEX
+    assert validate Channel
   end
 end


### PR DESCRIPTION
I have no idea what "It's not possible to match a binary prefix through gproc/ets" means, but as far as I can tell this fixes edgurgel/poxa#16

Please... be gentle.