### PR TITLE
Web hook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ How do I speak 'poxa'?
 * [x] Complete REST api;
 * [ ] Mimic pusher error codes;
 * [ ] Integration test using pusher-js or other client library;
-* [ ] Web hooks;
+* [x] Web hooks;
 * [ ] Specify types signature to functions and use dialyzer to check them on Travis;
 * [ ] Add 'Vacated' and 'Occupied' events to Console;
 * [X] Use GenEvent to generate Console events so other handlers can be attached (Web hook for example);

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,4 +9,5 @@ config :poxa,
   port: get_env("PORT") || 8080,
   app_key: get_env("POXA_APP_KEY") || "app_key",
   app_secret: get_env("POXA_SECRET") || "secret",
-  app_id: get_env("POXA_APP_ID") || "app_id"
+  app_id: get_env("POXA_APP_ID") || "app_id",
+  web_hook: get_env("WEB_HOOK") || nil

--- a/lib/poxa/event.ex
+++ b/lib/poxa/event.ex
@@ -1,5 +1,5 @@
 defmodule Poxa.Event do
-  def notify(event, data), do: :gen_event.sync_notify(Poxa.Event, Map.put(data, :event, event))
+  def notify(event, data), do: GenEvent.sync_notify(Poxa.Event, Map.put(data, :event, event))
 
   def add_handler(handler, pid) do
     GenEvent.add_mon_handler(Poxa.Event, handler, pid)

--- a/lib/poxa/event.ex
+++ b/lib/poxa/event.ex
@@ -1,5 +1,5 @@
 defmodule Poxa.Event do
-  def notify(event, data), do: GenEvent.sync_notify(Poxa.Event, Map.put(data, :event, event))
+  def notify(event, data), do: GenEvent.ack_notify(Poxa.Event, Map.put(data, :event, event))
 
   def add_handler(handler, pid) do
     GenEvent.add_mon_handler(Poxa.Event, handler, pid)

--- a/lib/poxa/supervisor.ex
+++ b/lib/poxa/supervisor.ex
@@ -10,7 +10,12 @@ defmodule Poxa.Supervisor do
   The supervisor will spawn a GenEvent named Poxa.Event
   """
   def init([]) do
+    {:ok, web_hook} = Application.fetch_env(:poxa, :web_hook)
     children = [worker(GenEvent, [[name: Poxa.Event]])]
+    if web_hook do
+      web_wook_worker = worker(Watcher, [Poxa.Event, Poxa.WebHook, []])
+      children = children ++ [web_wook_worker]
+    end
     supervise children, strategy: :one_for_one
   end
 end

--- a/lib/poxa/web_hook.ex
+++ b/lib/poxa/web_hook.ex
@@ -1,0 +1,62 @@
+defmodule Poxa.WebHook do
+  use GenEvent
+  alias Poxa.Channel
+  alias Poxa.WebHookEvent
+  alias Poxa.CryptoHelper
+
+  @doc false
+  def handle_event(%{event: :connected}, []) do
+    # It cannot trigger any webhook event
+    {:ok, []}
+  end
+
+  def handle_event(%{event: :disconnected, channels: channels}, []) do
+    for c <- channels, !Channel.occupied?(c) do
+      WebHookEvent.channel_vacated(c)
+    end |> send_web_hook
+  end
+
+  def handle_event(%{event: :subscribed, channel: channel}, []) do
+    for c <- [channel], Channel.subscription_count(c) == 1 do
+      WebHookEvent.channel_occupied(c)
+    end |> send_web_hook
+  end
+
+  def handle_event(%{event: :unsubscribed, channel: channel}, []) do
+    for c <- [channel], !Channel.occupied?(c) do
+      WebHookEvent.channel_vacated(c)
+    end |> send_web_hook
+  end
+
+  def handle_event(%{event: :api_message}, []) do
+    # It cannot trigger any webhook event
+    {:ok, []}
+  end
+
+  def handle_event(%{event: :client_event_message, socket_id: socket_id, channels: channels, name: name, data: data}, []) do
+    for c <- channels do
+      WebHookEvent.client_event(c, name, data, socket_id, nil)
+    end |> send_web_hook
+  end
+
+  defp send_web_hook([]), do: {:ok, []}
+  defp send_web_hook(events) do
+    body = JSX.encode! %{time_ms: time_ms, events: events}
+    {:ok, url} = Application.fetch_env(:poxa, :web_hook)
+    case HTTPoison.post(url, body, pusher_headers(body)) do
+      {:ok, _} -> {:ok, []}
+      error -> error
+    end
+  end
+
+  defp pusher_headers(body) do
+    {:ok, app_key} = Application.fetch_env(:poxa, :app_key)
+    {:ok, app_secret} = Application.fetch_env(:poxa, :app_secret)
+    %{
+      "X-Pusher-Key"       => app_key,
+      "X-Pusher-Signature" => CryptoHelper.hmac256_to_string(app_secret, body)
+    }
+  end
+
+  defp time_ms, do: :erlang.system_time(1000)
+end

--- a/lib/poxa/web_hook_event.ex
+++ b/lib/poxa/web_hook_event.ex
@@ -1,0 +1,100 @@
+defmodule Poxa.WebHookEvent do
+  @moduledoc """
+  This module contains a set of functions to generate web hook events.
+
+  Take a look at https://pusher.com/docs/webhooks#events for more details.
+  """
+
+  alias Poxa.PresenceSubscription
+
+  @doc """
+  Returns a map describing the event happening whenever any channel becomes occupied (i.e. there is at least one subscriber).
+
+  ## Example
+
+      iex> Poxa.WebHookEvent.channel_occupied("test_channel")
+      %{name: "channel_occupied", channel: "test_channel"}
+  """
+  @spec channel_occupied(binary) :: map
+  def channel_occupied(channel) do
+    %{name: "channel_occupied", channel: channel}
+  end
+
+  @doc """
+  Returns a map describing the event happening whenever any channel becomes vacated (i.e. there is no subscriber).
+
+  ## Example
+
+      iex> Poxa.WebHookEvent.channel_vacated("test_channel")
+      %{name: "channel_vacated", channel: "test_channel"}
+  """
+  @spec channel_vacated(binary) :: map
+  def channel_vacated(channel) do
+    %{name: "channel_vacated", channel: channel}
+  end
+
+  @doc """
+  Returns a map describing the event happening whenever a new user subscribes to a presence channel.
+
+  ## Example
+
+      iex> Poxa.WebHookEvent.member_added("presence-test_channel", "test_user_id")
+      %{name: "member_added", channel: "presence-test_channel", user_id: "test_user_id"}
+  """
+  @spec member_added(binary, PresenceSubscription.user_id) :: map
+  def member_added(channel, user_id) do
+    %{name: "member_added", channel: channel, user_id: user_id}
+  end
+
+  @doc """
+  Returns a map describing the event happening whenever a new user unsubscribes from a presence channel.
+
+  ## Example
+
+      iex> Poxa.WebHookEvent.member_removed("presence-test_channel", "test_user_id")
+      %{name: "member_removed", channel: "presence-test_channel", user_id: "test_user_id"}
+  """
+  @spec member_removed(binary, PresenceSubscription.user_id) :: map
+  def member_removed(channel, user_id) do
+    %{name: "member_removed", channel: channel, user_id: user_id}
+  end
+
+  @doc """
+  Returns a map describing the event happening whenever a client event is sent on any channel.
+
+  ## Examples
+
+      iex> Poxa.WebHookEvent.client_event("test_channel", "event name", "associated data", "test_socket_id", "test_user_id")
+      %{
+        name: "client_event",
+        channel: "test_channel",
+        event: "event name",
+        data: "associated data",
+        socket_id: "test_socket_id",
+        user_id: "test_user_id"
+      }
+
+      iex> Poxa.WebHookEvent.client_event("test_channel", "event name", %{associated: "data"}, "test_socket_id", nil)
+      %{
+        name: "client_event",
+        channel: "test_channel",
+        event: "event name",
+        data: %{associated: "data"},
+        socket_id: "test_socket_id",
+      }
+  """
+  @spec client_event(binary, binary, any, binary, PresenceSubscription.user_id | nil) :: map
+  def client_event(channel, event, data, socket_id, nil) do
+    Map.delete(client_event(channel, event, data, socket_id, ""), :user_id)
+  end
+
+  def client_event(channel, event, data, socket_id, user_id) do
+    %{name: "client_event",
+      channel: channel,
+      event: event,
+      data: data,
+      socket_id: socket_id,
+      user_id: user_id
+    }
+  end
+end

--- a/lib/poxa/websocket_handler.ex
+++ b/lib/poxa/websocket_handler.ex
@@ -106,7 +106,7 @@ defmodule Poxa.WebsocketHandler do
     channel = List.first(event.channels)
     if Channel.private_or_presence?(channel) and Channel.subscribed?(channel, self) do
       PusherEvent.publish(event)
-      Event.notify(:client_event_message, %{socket_id: socket_id, channels: event.channels, name: event.name})
+      Event.notify(:client_event_message, %{socket_id: socket_id, channels: event.channels, name: event.name, data: event.data})
     end
     {:ok, req, state}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Poxa.Mixfile do
   end
 
   def application do
-    [ applications: [ :logger, :crypto, :gproc, :cowboy, :asn1, :public_key, :ssl, :exjsx, :signaturex ],
+    [ applications: [ :logger, :crypto, :gproc, :cowboy, :asn1, :public_key, :ssl, :exjsx, :signaturex, :httpoison ],
       mod: { Poxa, [] } ]
   end
 
@@ -24,6 +24,7 @@ defmodule Poxa.Mixfile do
       {:pusher, "~> 0.1.0", only: :test},
       {:exrm, "~> 0.19.2", only: :prod},
       {:edip, "~> 0.4", only: :prod},
-      {:inch_ex, only: :docs} ]
+      {:inch_ex, only: :docs},
+      {:httpoison, "~> 0.8"} ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Poxa.Mixfile do
   end
 
   def application do
-    [ applications: [ :logger, :crypto, :gproc, :cowboy, :asn1, :public_key, :ssl, :exjsx, :signaturex, :httpoison ],
+    [ applications: [ :logger, :crypto, :gproc, :cowboy, :asn1, :public_key, :ssl, :exjsx, :signaturex, :httpoison, :watcher ],
       mod: { Poxa, [] } ]
   end
 
@@ -25,6 +25,7 @@ defmodule Poxa.Mixfile do
       {:exrm, "~> 0.19.2", only: :prod},
       {:edip, "~> 0.4", only: :prod},
       {:inch_ex, only: :docs},
-      {:httpoison, "~> 0.8"} ]
+      {:httpoison, "~> 0.8"},
+      {:watcher, "~> 1.0.0"} ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -25,4 +25,5 @@
   "relx": {:hex, :relx, "3.1.0"},
   "signaturex": {:hex, :signaturex, "0.0.8"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
-  "websocket_client": {:git, "git://github.com/jeremyong/websocket_client.git", "2b8d9805306d36f22330f432ae6472f1f2625c30", []}}
+  "watcher": {:hex, :watcher, "1.0.0"},
+  "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "2b8d9805306d36f22330f432ae6472f1f2625c30", []}}

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -1,0 +1,29 @@
+defmodule Poxa.EventTest do
+  use ExUnit.Case
+  alias Poxa.Event
+
+  defmodule TestHandler do
+    use GenEvent
+
+    def handle_event(%{event: :failed_handling}, _pid) do
+      :error
+    end
+
+    def handle_event(event_data, pid) do
+      send pid, event_data
+      {:ok, pid}
+    end
+  end
+
+  test "notifies handler" do
+    :ok = Event.add_handler({TestHandler, self}, self)
+    :ok = Event.notify(:successful_handling, %{data: :map})
+    assert_receive %{event: :successful_handling, data: :map}
+  end
+
+  test "handler failures are notified" do
+    :ok = Event.add_handler({TestHandler, self}, self)
+    :ok = Event.notify(:failed_handling, %{})
+    assert_receive {:gen_event_EXIT, _, _}
+  end
+end

--- a/test/web_hook_event_test.exs
+++ b/test/web_hook_event_test.exs
@@ -1,0 +1,4 @@
+defmodule Poxa.WebHookEventTest do
+  use ExUnit.Case, async: true
+  doctest Poxa.WebHookEvent
+end

--- a/test/web_hook_test.exs
+++ b/test/web_hook_test.exs
@@ -1,0 +1,87 @@
+defmodule Poxa.WebHookTest do
+  use ExUnit.Case
+  alias Poxa.Channel
+  import :meck
+  import Poxa.WebHook
+
+  setup_all do
+    :application.set_env(:poxa, :app_secret, "secret")
+    :application.set_env(:poxa, :app_key, "app_key")
+    :application.set_env(:poxa, :web_hook, "web_hook_url")
+
+    new HTTPoison
+    expect HTTPoison, :post, fn url, body, headers ->
+      args_map = %{url: url, body: JSX.decode!(body), headers: headers}
+      send(self, args_map)
+      {:ok, args_map}
+    end
+
+    new Channel
+
+    on_exit fn -> unload end
+    :ok
+  end
+
+  test "connected" do
+    assert {:ok, []} == handle_event(%{event: :connected}, [])
+  end
+
+  test "disconnected" do
+    expect Channel, :occupied?, fn
+      "channel_1" -> false
+      "channel_2" -> true
+    end
+    assert {:ok, []} == handle_event(%{event: :disconnected, channels: ~w(channel_1 channel_2)}, [])
+    assert_received %{
+      url: "web_hook_url",
+      body: %{"events" => [%{"channel" => "channel_1", "name" => "channel_vacated"}]},
+      headers: _headers
+    }
+  end
+
+  test "subscribed sends channel_occupied event" do
+    expect Channel, :subscription_count, fn _ -> 1 end
+    assert {:ok, []} == handle_event(%{event: :subscribed, channel: "my_channel"}, [])
+    assert_received %{
+      url: "web_hook_url",
+      body: %{"events" => [%{"channel" => "my_channel", "name" => "channel_occupied"}]},
+      headers: _headers
+    }
+  end
+
+  test "subscribed does not send channel_occupied event" do
+    expect Channel, :subscription_count, fn _ -> 2 end
+    assert {:ok, []} == handle_event(%{event: :subscribed, channel: "my_channel"}, [])
+    refute_received %{url: _url, body: _body, headers: _headers}
+  end
+
+  test "unsubscribed sends channel_vacated event" do
+    expect Channel, :occupied?, fn _ -> false end
+    assert {:ok, []} == handle_event(%{event: :unsubscribed, channel: "my_channel"}, [])
+    assert_received %{
+      url: "web_hook_url",
+      body: %{"events" => [%{"channel" => "my_channel", "name" => "channel_vacated"}]},
+      headers: _headers
+    }
+  end
+
+  test "unsubscribed does not send channel_vacated event" do
+    expect Channel, :occupied?, fn _ -> true end
+    assert {:ok, []} == handle_event(%{event: :unsubscribed, channel: "my_channel"}, [])
+    refute_received %{url: _url, body: _body, headers: _headers}
+  end
+
+  test "client_event_message" do
+    assert {:ok, []} == handle_event(%{event: :client_event_message, socket_id: "socket_id", channels: ~w(channel_1 channel_2), name: "my_event", data: "data"}, [])
+    assert_received %{
+      url: "web_hook_url",
+      body: %{"events" =>
+        [
+          %{"channel" => "channel_1", "name" => "client_event", "data" => "data", "socket_id" => "socket_id"},
+          %{"channel" => "channel_2", "name" => "client_event", "data" => "data", "socket_id" => "socket_id"}
+        ]
+      },
+      headers: _headers
+    }
+  end
+end


### PR DESCRIPTION
This is an experimental support of the [Pusher's web hook feature](https://pusher.com/docs/webhooks). It is related to #22.

The approach here is to support multiple events in a restricted way and improve the implementation in baby steps. :bomb::bomb::bomb::bomb:

Implementation restrictions
- **Batch web hooks are not fully supported.** Events related to multiple channels will naturally create multiple events in a same payload. However, It doesn't support delaying events and then delivering them as a batch.
- **Presence channel events.** To implement this, we need to refactor some aspects of event notification in Poxa. This would be quite drastic for a first try so it will done later.