### PR TITLE
Web hook adjustments

### DIFF
--- a/lib/poxa/console/console.ex
+++ b/lib/poxa/console/console.ex
@@ -36,6 +36,16 @@ defmodule Poxa.Console do
     {:ok, pid}
   end
 
+  def handle_event(%{event: :member_added, channel: channel, user_id: user_id}, pid) do
+    send_message("Member added", nil, "Channel: #{inspect channel}, UserId: #{inspect user_id}", pid)
+    {:ok, pid}
+  end
+
+  def handle_event(%{event: :member_removed, channel: channel, user_id: user_id}, pid) do
+    send_message("Member removed", nil, "Channel: #{inspect channel}, UserId: #{inspect user_id}", pid)
+    {:ok, pid}
+  end
+
   defp send_message(type, socket_id, details, pid) do
     msg = message(type, socket_id, details) |> encode!
     send(pid, msg)

--- a/lib/poxa/presence_subscription.ex
+++ b/lib/poxa/presence_subscription.ex
@@ -15,6 +15,7 @@ defmodule Poxa.PresenceSubscription do
   @type t :: %__MODULE__{channel: binary, channel_data: [{user_id, user_info}]}
 
   alias Poxa.PusherEvent
+  alias Poxa.Event
   import Poxa.Channel, only: [presence?: 1, subscribed?: 2]
   require Logger
 
@@ -30,6 +31,7 @@ defmodule Poxa.PresenceSubscription do
       Logger.info "Registering #{inspect self} to channel #{channel}"
       {user_id, user_info} = extract_userid_and_userinfo(decoded_channel_data)
       unless user_id_already_on_presence_channel(user_id, channel) do
+        Event.notify(:member_added, %{channel: channel, user_id: user_id})
         message = PusherEvent.presence_member_added(channel, user_id, user_info)
         :gproc.send({:p, :l, {:pusher, channel}}, {self, message})
       end
@@ -92,6 +94,7 @@ defmodule Poxa.PresenceSubscription do
   end
 
   defp presence_member_removed(channel, user_id) do
+    Event.notify(:member_removed, %{channel: channel, user_id: user_id})
     message = PusherEvent.presence_member_removed(channel, user_id)
     :gproc.send({:p, :l, {:pusher, channel}}, {self, message})
   end

--- a/lib/poxa/web_hook.ex
+++ b/lib/poxa/web_hook.ex
@@ -41,6 +41,7 @@ defmodule Poxa.WebHook do
     end |> send_web_hook
   end
 
+  defp send_web_hook(event) when not is_list(event), do: send_web_hook([event])
   defp send_web_hook([]), do: {:ok, []}
   defp send_web_hook(events) do
     body = JSX.encode! %{time_ms: time_ms, events: events}
@@ -55,6 +56,7 @@ defmodule Poxa.WebHook do
     {:ok, app_key} = Application.fetch_env(:poxa, :app_key)
     {:ok, app_secret} = Application.fetch_env(:poxa, :app_secret)
     %{
+      "Content-Type"       => "application/json",
       "X-Pusher-Key"       => app_key,
       "X-Pusher-Signature" => CryptoHelper.hmac256_to_string(app_secret, body)
     }

--- a/lib/poxa/web_hook.ex
+++ b/lib/poxa/web_hook.ex
@@ -5,10 +5,9 @@ defmodule Poxa.WebHook do
   alias Poxa.CryptoHelper
 
   @doc false
-  def handle_event(%{event: :connected}, []) do
-    # It cannot trigger any webhook event
-    {:ok, []}
-  end
+  # Events that cannot trigger any webhook event
+  def handle_event(%{event: :api_message}, []), do: {:ok, []}
+  def handle_event(%{event: :connected}, []), do: {:ok, []}
 
   def handle_event(%{event: :disconnected, channels: channels}, []) do
     for c <- channels, !Channel.occupied?(c) do
@@ -28,9 +27,12 @@ defmodule Poxa.WebHook do
     end |> send_web_hook
   end
 
-  def handle_event(%{event: :api_message}, []) do
-    # It cannot trigger any webhook event
-    {:ok, []}
+  def handle_event(%{event: :member_added, channel: channel, user_id: user_id}, []) do
+    WebHookEvent.member_added(channel, user_id) |> send_web_hook
+  end
+
+  def handle_event(%{event: :member_removed, channel: channel, user_id: user_id}, []) do
+    WebHookEvent.member_removed(channel, user_id) |> send_web_hook
   end
 
   def handle_event(%{event: :client_event_message, socket_id: socket_id, channels: channels, name: name, data: data}, []) do

--- a/lib/poxa/websocket_handler.ex
+++ b/lib/poxa/websocket_handler.ex
@@ -159,9 +159,9 @@ defmodule Poxa.WebsocketHandler do
   def websocket_terminate(_reason, _req, %State{socket_id: socket_id, time: time}) do
     duration = Time.stamp - time
     channels = Channel.all(self)
-    Event.notify(:disconnected, %{socket_id: socket_id, channels: channels, duration: duration})
     PresenceSubscription.check_and_remove
     :gproc.goodbye
+    Event.notify(:disconnected, %{socket_id: socket_id, channels: channels, duration: duration})
     :ok
   end
 end

--- a/test/console/console_test.exs
+++ b/test/console/console_test.exs
@@ -45,4 +45,16 @@ defmodule Poxa.ConsoleTest do
 
     assert_received %{details: "Channels: [\"channel\"], Event: event_message", socket: "socket_id", time: _, type: "Client Event Message"}
   end
+
+  test "member_added" do
+    handle_event(%{event: :member_added, channel: "presence-channel", user_id: "user_id"}, self)
+
+    assert_received %{details: "Channel: \"presence-channel\", UserId: \"user_id\"", socket: nil, time: _, type: "Member added"}
+  end
+
+  test "member_removed" do
+    handle_event(%{event: :member_removed, channel: "presence-channel", user_id: "user_id"}, self)
+
+    assert_received %{details: "Channel: \"presence-channel\", UserId: \"user_id\"", socket: nil, time: _, type: "Member removed"}
+  end
 end


### PR DESCRIPTION
Some adjustments in the web hooks in this PR

- Implemented missing events `member_added` and `member_removed` #66 
- Set content type of requests to JSON
- Invert order of `gproc.goodbye` and disconnection notification.

I also tested the whole web hook support with the Pusher ruby gem as you suggested and everything is working fine now :dancer: 