### PR TITLE
Add channel vacated and occupied events to console

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ How do I speak 'poxa'?
 * [x] Mimic pusher error codes;
 * [x] Integration test using pusher-js or other client library;
 * [x] Web hooks;
-* [ ] Add 'Vacated' and 'Occupied' events to Console;
+* [x] Add 'Vacated' and 'Occupied' events to Console;
 * [X] Use GenEvent to generate Console events so other handlers can be attached (Web hook for example);
 * [ ] Turn Poxa on a distributed server with multiple nodes;
 

--- a/lib/poxa/channel.ex
+++ b/lib/poxa/channel.ex
@@ -87,10 +87,7 @@ defmodule Poxa.Channel do
   Returns true if the channel has at least 1 subscription
   """
   @spec occupied?(binary) :: boolean
-  def occupied?(channel) do
-    match = {{:p, :l, {:pusher, channel}}, :_, :_}
-    :gproc.select_count([{match, [], [true]}]) != 0
-  end
+  def occupied?(channel), do: subscribed?(channel)
 
   @doc """
   Returns the list of channels the `pid` is subscribed
@@ -104,18 +101,15 @@ defmodule Poxa.Channel do
   @doc """
   Returns true if `pid` is subscribed to `channel` and false otherwise
   """
-  @spec subscribed?(binary, pid) :: boolean
-  def subscribed?(channel, pid) do
-    match = {{:p, :l, {:pusher, channel}}, pid, :_}
-    :gproc.select_count([{match, [], [true]}]) != 0
-  end
+  @spec subscribed?(binary, pid | :_) :: boolean
+  def subscribed?(channel, pid \\ :_), do: subscription_count(channel, pid) != 0
 
   @doc """
   Returns how many connections are opened on the `channel`
   """
-  @spec subscription_count(binary) :: non_neg_integer
-  def subscription_count(channel) do
-    match = {{:p, :l, {:pusher, channel}}, :_, :_}
+  @spec subscription_count(binary, pid | :_) :: non_neg_integer
+  def subscription_count(channel, pid \\ :_) do
+    match = {{:p, :l, {:pusher, channel}}, pid, :_}
     :gproc.select_count([{match, [], [true]}])
   end
 end

--- a/lib/poxa/console/console.ex
+++ b/lib/poxa/console/console.ex
@@ -46,6 +46,16 @@ defmodule Poxa.Console do
     {:ok, pid}
   end
 
+  def handle_event(%{event: :channel_vacated, channel: channel, socket_id: socket_id}, pid) do
+    send_message("Channel vacated", socket_id, "Channel: #{inspect channel}", pid)
+    {:ok, pid}
+  end
+
+  def handle_event(%{event: :channel_occupied, channel: channel, socket_id: socket_id}, pid) do
+    send_message("Channel occupied", socket_id, "Channel: #{inspect channel}", pid)
+    {:ok, pid}
+  end
+
   defp send_message(type, socket_id, details, pid) do
     msg = message(type, socket_id, details) |> encode!
     send(pid, msg)

--- a/lib/poxa/event.ex
+++ b/lib/poxa/event.ex
@@ -1,5 +1,5 @@
 defmodule Poxa.Event do
-  def notify(event, data), do: GenEvent.ack_notify(Poxa.Event, Map.put(data, :event, event))
+  def notify(event, data), do: GenEvent.notify(Poxa.Event, Map.put(data, :event, event))
 
   def add_handler(handler, pid) do
     GenEvent.add_mon_handler(Poxa.Event, handler, pid)

--- a/lib/poxa/subscription_handler.ex
+++ b/lib/poxa/subscription_handler.ex
@@ -1,0 +1,32 @@
+defmodule Poxa.SubscriptionHandler do
+  @moduledoc """
+  This module will be responsible for notifying when channels get occupied or vacated.
+  """
+
+  use GenEvent
+  alias Poxa.Channel
+  import Poxa.Event, only: [notify: 2]
+
+  def handle_event(%{event: :disconnected, channels: channels, socket_id: socket_id}, []) do
+    for c <- channels, !Channel.occupied?(c) do
+      notify(:channel_vacated, %{channel: c, socket_id: socket_id})
+    end
+    {:ok, []}
+  end
+
+  def handle_event(%{event: :subscribed, channel: channel, socket_id: socket_id}, []) do
+    if Channel.subscription_count(channel) == 1 do
+      notify(:channel_occupied, %{channel: channel, socket_id: socket_id})
+    end
+    {:ok, []}
+  end
+
+  def handle_event(%{event: :unsubscribed, channel: channel, socket_id: socket_id}, []) do
+    unless Channel.occupied?(channel) do
+      notify(:channel_vacated, %{channel: channel, socket_id: socket_id})
+    end
+    {:ok, []}
+  end
+
+  def handle_event(_, []), do: {:ok, []}
+end

--- a/lib/poxa/supervisor.ex
+++ b/lib/poxa/supervisor.ex
@@ -11,9 +11,11 @@ defmodule Poxa.Supervisor do
   """
   def init([]) do
     {:ok, web_hook} = Application.fetch_env(:poxa, :web_hook)
-    children = [worker(GenEvent, [[name: Poxa.Event]])]
+    event_worker = worker(GenEvent, [[name: Poxa.Event]])
+    subscription_worker = worker(Watcher, [Poxa.Event, Poxa.SubscriptionHandler, []], [id: Poxa.SubscriptionHandler])
+    children = [event_worker, subscription_worker]
     if web_hook do
-      web_wook_worker = worker(Watcher, [Poxa.Event, Poxa.WebHook, []])
+      web_wook_worker = worker(Watcher, [Poxa.Event, Poxa.WebHook, []], [id: Poxa.WebHook])
       children = children ++ [web_wook_worker]
     end
     supervise children, strategy: :one_for_one

--- a/test/console/console_test.exs
+++ b/test/console/console_test.exs
@@ -57,4 +57,17 @@ defmodule Poxa.ConsoleTest do
 
     assert_received %{details: "Channel: \"presence-channel\", UserId: \"user_id\"", socket: nil, time: _, type: "Member removed"}
   end
+
+  test "channel_occupied" do
+    handle_event(%{event: :channel_occupied, channel: "channel", socket_id: "socket_id"}, self)
+
+    assert_received %{details: "Channel: \"channel\"", socket: "socket_id", time: _, type: "Channel occupied"}
+  end
+
+
+  test "channel_vacated" do
+    handle_event(%{event: :channel_vacated, channel: "channel", socket_id: "socket_id"}, self)
+
+    assert_received %{details: "Channel: \"channel\"", socket: "socket_id", time: _, type: "Channel vacated"}
+  end
 end

--- a/test/subscription_handler_test.exs
+++ b/test/subscription_handler_test.exs
@@ -1,0 +1,50 @@
+defmodule Poxa.SubscriptionHandlerTest do
+  use ExUnit.Case
+  alias Poxa.Event
+  alias Poxa.Channel
+  import :meck
+  import Poxa.SubscriptionHandler
+
+  setup_all do
+    expect Event, :notify, fn event, event_data ->
+      send(self, {event, event_data})
+      :ok
+    end
+
+    on_exit fn -> unload end
+    :ok
+  end
+
+  test "disconnected" do
+    expect Channel, :occupied?, fn
+      "channel_1" -> false
+      "channel_2" -> true
+    end
+    assert {:ok, []} == handle_event(%{event: :disconnected, channels: ~w(channel_1 channel_2), socket_id: "socket_id"}, [])
+    assert_received {:channel_vacated, %{channel: "channel_1"}}
+  end
+
+  test "subscribed sends channel_occupied event on first subscription" do
+    expect Channel, :subscription_count, fn _ -> 1 end
+    assert {:ok, []} == handle_event(%{event: :subscribed, channel: "my_channel", socket_id: "socket_id"}, [])
+    assert_received {:channel_occupied, %{channel: "my_channel"}}
+  end
+
+  test "subscribed does not send channel_occupied event other than first subscription" do
+    expect Channel, :subscription_count, fn _ -> 2 end
+    assert {:ok, []} == handle_event(%{event: :subscribed, channel: "my_channel", socket_id: "socket_id"}, [])
+    refute_received {:channel_occupied, %{channel: "my_channel"}}
+  end
+
+  test "unsubscribed sends channel_vacated event" do
+    expect Channel, :occupied?, fn _ -> false end
+    assert {:ok, []} == handle_event(%{event: :unsubscribed, channel: "my_channel", socket_id: "socket_id"}, [])
+    assert_received {:channel_vacated, %{channel: "my_channel"}}
+  end
+
+  test "unsubscribed does not send channel_vacated event" do
+    expect Channel, :occupied?, fn _ -> true end
+    assert {:ok, []} == handle_event(%{event: :unsubscribed, channel: "my_channel", socket_id: "socket_id"}, [])
+    refute_received {:channel_vacated, %{channel: "my_channel"}}
+  end
+end


### PR DESCRIPTION
This transfers the implementation of channel vacated and occupied to a dedicated event handler that will analyze subscribed, unsubscribed and disconnect events. It then notifies the manager when channel vacated and occupied events. This way, the console and the web hook can watch for this event.

I had to change `GenEvent.ack_notify` to `GenEvent.notify` to allow event handlers to notify events. Then we can have dedicated handlers responsible for specific events that can notify other handlers. As it is the case with the SubscriptionHandler. With `ack_notify` it was resulting in a deadlock.

This closes #70 