### PR TITLE
Move gproc code to a registry adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ elixir:
 sudo: false
 env:
   - MIX_ENV=test
+env:
+  matrix:
+    - POXA_REGISTRY_ADAPTER=gproc
 after_script:
   - mix deps.get --only docs
   - MIX_ENV=docs mix inch.report

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,4 +10,5 @@ config :poxa,
   app_key: get_env("POXA_APP_KEY") || "app_key",
   app_secret: get_env("POXA_SECRET") || "secret",
   app_id: get_env("POXA_APP_ID") || "app_id",
+  registry_adapter: get_env("POXA_REGISTRY_ADAPTER") || "gproc",
   web_hook: get_env("WEB_HOOK") || nil

--- a/lib/poxa.ex
+++ b/lib/poxa.ex
@@ -6,6 +6,10 @@ defmodule Poxa do
   use Application
   require Logger
 
+  @registry_adapter Poxa.Registry.adapter
+
+  def registry, do: @registry_adapter
+
   def start(_type, _args) do
     dispatch = :cowboy_router.compile([
       {:_, [ { '/ping', Poxa.PingHandler, [] },
@@ -40,8 +44,10 @@ defmodule Poxa do
       {:ok, app_id} = Application.fetch_env(:poxa, :app_id)
       {:ok, app_secret} = Application.fetch_env(:poxa, :app_secret)
       {:ok, port} = Application.fetch_env(:poxa, :port)
+      {:ok, registry_adapter} = Application.fetch_env(:poxa, :registry_adapter)
       {:ok, %{app_key: app_key, app_id: app_id,
-              app_secret: app_secret, port: to_integer(port)}}
+              app_secret: app_secret, port: to_integer(port),
+              registry_adapter: registry_adapter}}
     rescue
       MatchError -> :invalid_configuration
     end

--- a/lib/poxa/adapter/gproc.ex
+++ b/lib/poxa/adapter/gproc.ex
@@ -1,0 +1,66 @@
+defmodule Poxa.Adapter.GProc do
+  @moduledoc """
+  Module that will enable using GProc as an adapter for Poxa registry.
+  """
+
+  @behaviour Poxa.Registry
+
+  import :gproc
+  require Ex2ms
+
+  def register!(key) do
+    reg({:p, :l, {:pusher, key}})
+  end
+
+  def register!(key, value) do
+    reg({:p, :l, {:pusher, key}}, value)
+  end
+
+  def unregister!(key) do
+    unreg({:p, :l, {:pusher, key}})
+  end
+
+  def send!(message, channel, sender) do
+    :gproc.send({:p, :l, {:pusher, channel}}, {sender, message})
+  end
+
+  def send!(message, channel, sender, socket_id) do
+    :gproc.send({:p, :l, {:pusher, channel}}, {sender, message, socket_id})
+  end
+
+  def subscription_count(channel, pid \\ :_)
+  def subscription_count(channel, pid) when is_pid(pid) or pid == :_ do
+    Ex2ms.fun do
+      {{:p, :l, {:pusher, ^channel}}, ^pid, _} -> true
+    end |> select_count
+  end
+  def subscription_count(channel, user_id) do
+    Ex2ms.fun do
+      {{:p, :l, {:pusher, ^channel}}, _, {^user_id, _}} -> true
+    end |> select_count
+  end
+
+  def subscriptions(pid) do
+    Ex2ms.fun do
+      {{:p, :l, {:pusher, channel}}, ^pid, {user_id, _}} -> [channel, user_id]
+    end |> select
+  end
+
+  def channels(pid \\ :_) do
+    Ex2ms.fun do
+      {{:p, :l, {:pusher, channel}}, ^pid, _} -> channel
+    end |> select |> Enum.uniq
+  end
+
+  def unique_subscriptions(channel) do
+    for {_pid, {user_id, user_info}} <- lookup_values({:p, :l, {:pusher, channel}}) do
+      {user_id, user_info}
+    end |> Enum.uniq(fn {user_id, _} -> user_id end)
+  end
+
+  def fetch(key) do
+    get_value({:p, :l, {:pusher, key}})
+  end
+
+  def clean_up, do: goodbye
+end

--- a/lib/poxa/channel.ex
+++ b/lib/poxa/channel.ex
@@ -87,29 +87,25 @@ defmodule Poxa.Channel do
   Returns true if the channel has at least 1 subscription
   """
   @spec occupied?(binary) :: boolean
-  def occupied?(channel), do: subscribed?(channel)
+  def occupied?(channel), do: member?(channel)
 
   @doc """
   Returns the list of channels the `pid` is subscribed
   """
   @spec all(pid | :_) :: [binary]
-  def all(pid \\ :_) do
-    match = {{:p, :l, {:pusher, :'$1'}}, pid, :_}
-    :gproc.select([{match, [], [:'$1']}]) |> Enum.uniq
-  end
+  def all(pid \\ :_), do: Poxa.registry.channels(pid)
 
   @doc """
-  Returns true if `pid` is subscribed to `channel` and false otherwise
+  Returns a boolean indicating if the user identified by `identifier` is subscribed to the channel.
   """
-  @spec subscribed?(binary, pid | :_) :: boolean
-  def subscribed?(channel, pid \\ :_), do: subscription_count(channel, pid) != 0
+  @spec member?(binary, pid | :_ |  PresenceSubscription.user_id) :: boolean
+  def member?(channel, identifier \\ :_), do: subscription_count(channel, identifier) != 0
 
   @doc """
   Returns how many connections are opened on the `channel`
   """
   @spec subscription_count(binary, pid | :_) :: non_neg_integer
   def subscription_count(channel, pid \\ :_) do
-    match = {{:p, :l, {:pusher, channel}}, pid, :_}
-    :gproc.select_count([{match, [], [true]}])
+    Poxa.registry.subscription_count(channel, pid)
   end
 end

--- a/lib/poxa/presence_channel.ex
+++ b/lib/poxa/presence_channel.ex
@@ -10,20 +10,12 @@ defmodule Poxa.PresenceChannel do
   """
   @spec users(binary) :: [binary | integer]
   def users(channel) do
-    match = {{:p, :l, {:pusher, channel}}, :_, :'$1'}
-    :gproc.select([{match, [], [:'$1']}])
-    |> Enum.uniq(fn {user_id, _} -> user_id end)
-    |> Enum.map(fn {user_id, _} -> user_id end)
+    for {user_id, _} <- Poxa.registry.unique_subscriptions(channel), do: user_id
   end
 
   @doc """
   Returns the number of unique users on a presence channel
   """
   @spec user_count(binary) :: non_neg_integer
-  def user_count(channel) do
-    match = {{:p, :l, {:pusher, channel}}, :_, :'$1'}
-    :gproc.select([{match, [], [:'$1']}])
-    |> Enum.uniq(fn {user_id, _} -> user_id end)
-    |> Enum.count
-  end
+  def user_count(channel), do: channel |> users |> Enum.count
 end

--- a/lib/poxa/pusher_event.ex
+++ b/lib/poxa/pusher_event.ex
@@ -192,7 +192,7 @@ defmodule Poxa.PusherEvent do
 
   defp publish_event_to_channel(event, channel) do
     message = build_message(event, channel) |> encode!
-    :gproc.send({:p, :l, {:pusher, channel}}, {self, message, event.socket_id})
+    Poxa.registry.send!(message, channel, self, event.socket_id)
   end
 
   defp build_message(event, channel) do

--- a/lib/poxa/registry.ex
+++ b/lib/poxa/registry.ex
@@ -1,0 +1,66 @@
+defmodule Poxa.Registry do
+  @doc """
+  Registers a property for the current process.
+  """
+  @callback register!(String.t) :: any
+
+  @doc """
+  Registers a property for the current process with a given value.
+  """
+  @callback register!(String.t, any) :: any
+
+  @doc """
+  Unregisters a property for the current process.
+  """
+  @callback unregister!(String.t) :: any
+
+  @doc """
+  Sends a message to a channel and identify it as coming from the given sender.
+  """
+  @callback send!(String.t, String.t, PresenceSubscription.user_id | pid) :: any
+
+  @doc """
+  Sends a message to a channel and identify it as coming from the given sender
+  through a specific socket_id.
+  """
+  @callback send!(String.t, String.t, any, String.t) :: any
+
+  @doc """
+  Returns the subscription count of a channel. If a connection identifier is provided,
+  it counts only the subscriptions identified by the given identifier.
+  """
+  @callback subscription_count(String.t, PresenceSubscription.user_id | pid | :_) :: non_neg_integer
+
+  @doc """
+  Returns the presence channel subscriptions of the given process.
+  """
+  @callback subscriptions(pid) :: list()
+
+  @doc """
+  Returns the list of channels the `pid` is subscribed to.
+  """
+  @callback channels(pid) :: list(binary())
+
+  @doc """
+  Returns the unique subscriptions of the given channel.
+  """
+  @callback unique_subscriptions(String.t) :: list(tuple())
+
+  @doc """
+  Returns the value assigned with the given property.
+  """
+  @callback fetch(String.t) :: any
+
+  @doc """
+  Cleans up the registry data.
+  """
+  @callback clean_up() :: any
+
+  def adapter do
+    case Application.get_env(:poxa, :registry_adapter) do
+      "gproc" -> Poxa.Adapter.GProc
+      nil -> raise "adapter not configured"
+      adapter -> raise "adapter '#{adapter}' not found"
+    end
+  end
+end

--- a/lib/poxa/socket_id.ex
+++ b/lib/poxa/socket_id.ex
@@ -28,7 +28,7 @@ defmodule Poxa.SocketId do
   """
   @spec register!(String.t) :: true
   def register!(socket_id) do
-    :gproc.reg({:p, :l, :socket_id}, socket_id)
+    Poxa.registry.register!(:socket_id, socket_id)
   end
 
   @doc """
@@ -38,6 +38,6 @@ defmodule Poxa.SocketId do
   """
   @spec mine :: String.t
   def mine do
-    :gproc.get_value({:p, :l, :socket_id})
+    Poxa.registry.fetch(:socket_id)
   end
 end

--- a/lib/poxa/subscription.ex
+++ b/lib/poxa/subscription.ex
@@ -60,11 +60,11 @@ defmodule Poxa.Subscription do
 
   defp subscribe_channel(channel) do
     Logger.info "Subscribing to channel #{channel}"
-    if Channel.subscribed?(channel, self) do
+    if Channel.member?(channel, self) do
       Logger.info "Already subscribed #{inspect self} on channel #{channel}"
     else
       Logger.info "Registering #{inspect self} to channel #{channel}"
-      :gproc.reg({:p, :l, {:pusher, channel}})
+      Poxa.registry.register!(channel)
     end
     {:ok, channel}
   end
@@ -75,11 +75,11 @@ defmodule Poxa.Subscription do
   @spec unsubscribe!(:jsx.json_term) :: {:ok, binary}
   def unsubscribe!(data) do
     channel = data["channel"]
-    if Channel.subscribed?(channel, self) do
+    if Channel.member?(channel, self) do
       if Channel.presence?(channel) do
         PresenceSubscription.unsubscribe!(channel);
       end
-      :gproc.unreg({:p, :l, {:pusher, channel}});
+      Poxa.registry.unregister!(channel)
     else
       Logger.debug "Not subscribed to"
     end

--- a/mix.exs
+++ b/mix.exs
@@ -26,6 +26,7 @@ defmodule Poxa.Mixfile do
       {:edip, "~> 0.4", only: :prod},
       {:inch_ex, "~> 0.5.1", only: :docs},
       {:httpoison, "~> 0.8"},
+      {:ex2ms, "~> 1.4.0"},
       {:watcher, "~> 1.0.0"} ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -5,6 +5,7 @@
   "cowlib": {:hex, :cowlib, "1.0.2"},
   "edip": {:hex, :edip, "0.4.1"},
   "erlware_commons": {:hex, :erlware_commons, "0.13.0"},
+  "ex2ms": {:hex, :ex2ms, "1.4.0"},
   "exjsx": {:hex, :exjsx, "3.2.0"},
   "exrm": {:hex, :exrm, "0.19.2"},
   "getopt": {:hex, :getopt, "0.8.2"},

--- a/test/channel_test.exs
+++ b/test/channel_test.exs
@@ -27,18 +27,19 @@ defmodule Poxa.ChannelTest do
     register_to_channel("channel_1")
     register_to_channel("channel_2")
     register_to_channel("channel_3")
+    spawn_registered_process("channel4")
 
     assert all(self) == ["channel_1", "channel_2", "channel_3"]
   end
 
-  test "channel is subscribed? returning true" do
+  test "channel is member? returning true" do
     register_to_channel("subscribed channel")
 
-    assert subscribed?("subscribed channel", self)
+    assert member?("subscribed channel", self)
   end
 
   test "channel is subscribed returning false" do
-    refute subscribed?("an unoccupied channel", self)
+    refute member?("an unoccupied channel", self)
   end
 
   test "subscription_count on channel" do

--- a/test/poxa/adapter/gproc_test.exs
+++ b/test/poxa/adapter/gproc_test.exs
@@ -1,0 +1,146 @@
+defmodule Poxa.Adapter.GProcTest do
+  use ExUnit.Case
+
+  import Poxa.Adapter.GProc
+
+  def spawn_registered(channel, execution, value \\ nil) do
+    parent = self
+    child = spawn_link fn ->
+      if value do
+        register!(channel, value)
+      else
+        register!(channel)
+      end
+      send parent, {self, :registered}
+      execution.()
+    end
+    assert_receive {^child, :registered}
+    child
+  end
+
+  test "register a property without value" do
+    register!(:property)
+    assert :gproc.get_value({:p, :l, {:pusher, :property}})
+  end
+
+  test "register a property with a value" do
+    register!(:property, :value)
+    assert :gproc.get_value({:p, :l, {:pusher, :property}}) == :value
+  end
+
+  test "unregister a property" do
+    :gproc.reg({:p, :l, {:pusher, :property}})
+    unregister!(:property)
+    assert_raise ArgumentError, fn ->
+      assert :gproc.get_value({:p, :l, {:pusher, :property}})
+    end
+  end
+
+  test "send message to registered processes" do
+    parent = self
+    child = spawn_registered("channel", fn ->
+      receive do
+        {^parent, msg} ->
+          send parent, {self, msg}
+      end
+    end)
+
+    send!(:msg, "channel", self)
+    assert_receive {^child, :msg}
+  end
+
+  test "send message to registered processes with socket_id" do
+    parent = self
+    child = spawn_registered("channel", fn ->
+      receive do
+        {^parent, msg, socket_id} ->
+          send parent, {self, msg, socket_id}
+      end
+    end)
+
+    send!(:msg, "channel", self, :socket_id)
+    assert_receive {^child, :msg, :socket_id}
+  end
+
+  test "count subscriptions for pid" do
+    execution = fn ->
+      receive do
+        _ -> :ok
+      end
+    end
+    child1 = spawn_registered("channel1", execution)
+    child2 = spawn_registered("channel1", execution)
+
+    assert subscription_count("channel1") == 2
+    assert subscription_count("channel1", child1) == 1
+    assert subscription_count("channel1", child2) == 1
+  end
+
+  test "subscriptions" do
+    register!("presence-channel1", {"user123", "userinfo"})
+    register!("presence-channel2", {"user234", "userinfo"})
+    assert subscriptions(self) == [
+      ["presence-channel1", "user123"],
+      ["presence-channel2", "user234"]
+    ]
+  end
+
+  test "list channels processes are registered to" do
+    execution = fn ->
+      receive do
+        _ -> :ok
+      end
+    end
+    child_channel1 = spawn_registered("channel1", execution)
+    child_channel2 = spawn_registered("channel2", execution)
+
+    assert channels == ["channel1", "channel2"]
+    assert channels(child_channel1) == ["channel1"]
+    assert channels(child_channel2) == ["channel2"]
+  end
+
+  test "unique_subscriptions" do
+    execution = fn ->
+      receive do
+        _ -> :ok
+      end
+    end
+    spawn_registered("channel", execution, {"user1", "user1 info"})
+    spawn_registered("channel", execution, {"user1", "different user1 info"})
+    spawn_registered("channel", execution, {"user2", "user2 info"})
+
+    [{"user1", _}, {"user2", "user2 info"}] = unique_subscriptions("channel")
+  end
+
+  test "subscription_count" do
+    execution = fn ->
+      receive do
+        _ -> :ok
+      end
+    end
+    spawn_registered("channel", execution, {"user1", "user1 info"})
+    spawn_registered("channel", execution, {"user1", "different user1 info"})
+    spawn_registered("channel", execution, {"user2", "user2 info"})
+
+    assert subscription_count("channel", "user1") == 2
+    assert subscription_count("channel", "user2") == 1
+    assert subscription_count("channel", "user3") == 0
+    assert subscription_count("unknown_channel", "user1") == 0
+  end
+
+  test "fetch with no previous value" do
+    assert_raise ArgumentError, fn ->
+      assert :gproc.get_value({:p, :l, {:pusher, :property}})
+    end
+  end
+
+  test "fetch with property without previous value" do
+    :gproc.reg({:p, :l, {:pusher, :property}})
+    assert fetch(:property)
+  end
+
+  test "fetch with property with previous value" do
+    :gproc.reg({:p, :l, {:pusher, :property}}, :value)
+    assert fetch(:property) == :value
+  end
+end

--- a/test/presence_subscription_test.exs
+++ b/test/presence_subscription_test.exs
@@ -7,105 +7,106 @@ defmodule Poxa.PresenceSubscriptionTest do
   alias Poxa.PresenceSubscription
 
   setup do
-    new [PusherEvent, :gproc, Poxa.Event]
+    new [PusherEvent, Poxa.registry, Poxa.Event]
     on_exit fn -> unload end
     :ok
   end
 
   test "subscribe to a presence channel" do
-    expect(Channel, :subscribed?, 2, false)
-    expect(:gproc, :select_count, 1, 0)
-    expect(:gproc, :send, 2, :sent)
-    expect(:gproc, :reg, 2, :registered)
+    expect(Channel, :member?, 2, false)
+    expect(Poxa.Channel, :member?, 2, true)
+    expect(Poxa.registry, :send!, 3, :sent)
+    expect(Poxa.registry, :register!, 2, :registered)
     expect(PusherEvent, :presence_member_added, 3, :event_message)
     expect(Poxa.Event, :notify, [:member_added, %{channel: "presence-channel", user_id: "id123"}], :ok)
 
     user = {"id123", "info456"}
     other_user = {"id", "info"}
-    expect(:gproc, :lookup_values, 1, [{:pid, user}, {:other_pid, other_user}])
+    expect(Poxa.registry, :unique_subscriptions, fn
+      "presence-channel" -> [user, other_user]
+    end)
 
     assert subscribe!("presence-channel", "{ \"user_id\" : \"id123\", \"user_info\" : \"info456\" }") == %PresenceSubscription{channel: "presence-channel", channel_data: [user, other_user]}
 
-    assert validate [Channel, PusherEvent, :gproc, Poxa.Event]
+    assert validate [Channel, PusherEvent, Poxa.registry, Poxa.Event]
   end
 
   test "subscribe to a presence channel already subscribed" do
-    expect(Channel, :subscribed?, 2, true)
+    expect(Channel, :member?, 2, true)
     user = {"id123", "info456"}
-    expect(:gproc, :lookup_values, 1, [{:pid, user}])
+    expect(Poxa.registry, :unique_subscriptions, fn
+      "presence-channel" -> [user]
+    end)
 
     assert subscribe!("presence-channel", "{ \"user_id\" : \"id123\", \"user_info\" : \"info456\" }") == %PresenceSubscription{channel: "presence-channel", channel_data: [user]}
 
-    assert validate Channel
-    assert validate :gproc
+    assert validate [Channel, Poxa.registry]
   end
 
   test "subscribe to a presence channel having the same userid" do
-    expect(Channel, :subscribed?, 2, false)
-    expect(:gproc, :select_count, 1, 1) # true for user_id_already_on_presence_channel/2
-    expect(:gproc, :reg, 2, :registered)
+    expect(Channel, :member?, 2, false)
+    expect(Poxa.Channel, :member?, 2, true)
+    expect(Poxa.registry, :register!, 2, :registered)
     user = {"id123", "info456"}
-    expect(:gproc, :lookup_values, 1, [{:pid, user}, {:other_pid, user}])
+    expect(Poxa.registry, :unique_subscriptions, fn
+      "presence-channel" -> [user]
+    end)
 
     assert subscribe!("presence-channel", "{ \"user_id\" : \"id123\", \"user_info\" : \"info456\" }") == %PresenceSubscription{channel: "presence-channel", channel_data: [user]}
 
-    assert validate Channel
-    assert validate PusherEvent
-    assert validate :gproc
+    assert validate [Channel, PusherEvent, Poxa.registry]
   end
 
   test "unsubscribe to presence channel being subscribed" do
-    expect(:gproc, :select_count, 1, 1)
-    expect(:gproc, :get_value, 1, {:userid, :userinfo})
-    expect(:gproc, :send, 2, :sent)
+    expect(Poxa.registry, :subscription_count, 2, 1)
+    expect(Poxa.registry, :fetch, 1, {:userid, :userinfo})
+    expect(Poxa.registry, :send!, 3, :event_message)
     expect(PusherEvent, :presence_member_removed, 2, :event_message)
     expect(Poxa.Event, :notify, [:member_removed, %{channel: "presence-channel", user_id: :userid}], :ok)
 
     assert unsubscribe!("presence-channel") == {:ok, "presence-channel"}
 
-    assert validate [PusherEvent, :gproc, Poxa.Event]
+    assert validate [PusherEvent, Poxa.registry, Poxa.Event]
   end
 
   test "unsubscribe to presence channel being not subscribed" do
-    expect(:gproc, :select_count, 1, 0)
-    expect(:gproc, :get_value, 1, nil)
+    expect(Poxa.registry, :fetch, 1, nil)
     assert unsubscribe!("presence-channel") == {:ok, "presence-channel"}
-    assert validate :gproc
+    assert validate Poxa.registry
   end
 
   test "unsubscribe to presence channel having other connection with the same pid" do
-    expect(:gproc, :select_count, 1, 2)
-    expect(:gproc, :get_value, 1, {:userid, :userinfo})
-    expect(:gproc, :send, 2, :sent)
+    expect(Poxa.registry, :subscription_count, 2, 1)
+    expect(Poxa.registry, :fetch, 1, {:userid, :userinfo})
+    expect(Poxa.registry, :send!, 3, :sent)
+    expect(Poxa.Event, :notify, [:member_removed, %{channel: "presence-channel", user_id: :userid}], :ok)
     expect(PusherEvent, :presence_member_removed, 2, :event_message)
     assert unsubscribe!("presence-channel") == {:ok, "presence-channel"}
-    assert validate PusherEvent
-    assert validate :gproc
+    assert validate [PusherEvent, Poxa.registry, Poxa.Event]
   end
 
   test "check subscribed presence channels and remove having only one connection on userid" do
-    expect(:gproc, :select, 1, [["presence-channel", :userid]])
-    expect(:gproc, :select_count, 1, 1)
+    expect(Poxa.registry, :subscriptions, 1, [["presence-channel", :userid]])
+    expect(Poxa.registry, :subscription_count, 2, 1)
     expect(PusherEvent, :presence_member_removed, 2, :msg)
-    expect(:gproc, :send, 2, :ok)
+    expect(Poxa.registry, :send!, 3, :ok)
     expect(Poxa.Event, :notify, [:member_removed, %{channel: "presence-channel", user_id: :userid}], :ok)
 
-    assert check_and_remove == :ok
+    assert check_and_remove == 1
 
-    assert validate [PusherEvent, :gproc, Poxa.Event]
+    assert validate [PusherEvent, Poxa.registry, Poxa.Event]
   end
 
   test "check subscribed presence channels and remove having more than one connection on userid" do
-    expect(:gproc, :select, 1, [["presence-channel", :userid]])
-    expect(:gproc, :select_count, 1, 5)
-    assert check_and_remove == :ok
-    assert validate PusherEvent
-    assert validate :gproc
+    expect(Poxa.registry, :subscriptions, 1, [["presence-channel", :userid]])
+    expect(Poxa.registry, :subscription_count, 2, 5)
+    assert check_and_remove == 0
+    assert validate [PusherEvent, Poxa.registry]
   end
 
   test "check subscribed presence channels and find nothing to unsubscribe" do
-    expect(:gproc, :select, 1, [])
-    assert check_and_remove == :ok
-    assert validate :gproc
+    expect(Poxa.registry, :subscriptions, 1, [])
+    assert check_and_remove == 0
+    assert validate Poxa.registry
   end
 end

--- a/test/pusher_event_test.exs
+++ b/test/pusher_event_test.exs
@@ -5,6 +5,7 @@ defmodule Poxa.PusherEventTest do
   alias Poxa.PusherEvent
 
   setup do
+    new Poxa.registry
     on_exit fn -> unload end
     :ok
   end
@@ -118,23 +119,23 @@ defmodule Poxa.PusherEventTest do
   end
 
   test "sending message to a channel" do
-    expect(:gproc, :send, [{[{:p, :l, {:pusher, "channel123"}}, {self, :msg, nil}], :ok}])
+    expect(Poxa.registry, :send!, [{[:msg, "channel123", self, nil], :ok}])
     expected = %{channel: "channel123", data: "data", event: "event"}
     expect(JSX, :encode!, [{[expected], :msg}])
     event = %PusherEvent{channels: ["channel123"], data: "data", name: "event"}
 
     assert publish(event) == :ok
 
-    assert validate [:gproc, JSX]
+    assert validate [Poxa.registry, JSX]
   end
 
   test "sending message to channels excluding a socket id" do
     expected = %{channel: "channel123", data: %{}, event: "event"}
     expect(JSX, :encode!, [{[expected], :msg}])
-    expect(:gproc, :send, [{[{:p, :l, {:pusher, "channel123"}}, {self, :msg, "SocketId"}], :ok}])
+    expect(Poxa.registry, :send!, [{[:msg, "channel123", self, "SocketId"], :ok}])
 
     assert publish(%PusherEvent{data: %{}, channels: ["channel123"], name: "event", socket_id: "SocketId"}) == :ok
 
-    assert validate [:gproc, JSX]
+    assert validate [Poxa.registry, JSX]
   end
 end

--- a/test/socket_id_test.exs
+++ b/test/socket_id_test.exs
@@ -13,11 +13,11 @@ defmodule Poxa.SocketIdTest do
 
   test "register!" do
     SocketId.register!("my_socket_id")
-    assert :gproc.get_value({:p, :l, :socket_id}) == "my_socket_id"
+    assert Poxa.registry.fetch(:socket_id) == "my_socket_id"
   end
 
   test "mine" do
-    :gproc.reg({:p, :l, :socket_id}, "my_socket_id")
+    Poxa.registry.register!(:socket_id, "my_socket_id")
     assert SocketId.mine == "my_socket_id"
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,5 @@
 ExUnit.start
+ExUnit.configure(exclude: :pending)
 
 defmodule Connection do
   def connect do
@@ -27,6 +28,6 @@ defmodule SpawnHelper do
   end
 
   def register_to_channel(channel, value \\ :undefined) do
-    :gproc.reg({:p, :l, {:pusher, channel}}, value)
+    Poxa.registry.register!(channel, value)
   end
 end

--- a/test/websocket_handler_test.exs
+++ b/test/websocket_handler_test.exs
@@ -18,6 +18,7 @@ defmodule Poxa.WebsocketHandlerTest do
   end
 
   setup do
+    new Poxa.registry
     on_exit fn -> unload end
     :ok
   end
@@ -184,7 +185,7 @@ defmodule Poxa.WebsocketHandlerTest do
     expect(JSX, :decode!, [{[:client_event_json], decoded_json}])
     expect(PusherEvent, :build_client_event, [{[decoded_json, :socket_id], {:ok, event}}])
     expect(PusherEvent, :publish, 1, :ok)
-    expect(Channel, :subscribed?, 2, true)
+    expect(Channel, :member?, 2, true)
     expect(Event, :notify, [{[:client_event_message, %{socket_id: :socket_id, channels: ["presence-channel"], name: "client-event"}], :ok}])
 
     state = %State{socket_id: :socket_id}
@@ -201,7 +202,7 @@ defmodule Poxa.WebsocketHandlerTest do
     expect(JSX, :decode!, [{[:client_event_json], decoded_json}])
     expect(PusherEvent, :build_client_event, [{[decoded_json, :socket_id], {:ok, event}}])
     expect(PusherEvent, :publish, 1, :ok)
-    expect(Channel, :subscribed?, 2, true)
+    expect(Channel, :member?, 2, true)
     expect(Event, :notify, [{[:client_event_message, %{socket_id: :socket_id, channels: ["private-channel"], name: "client-event"}], :ok}])
 
     state = %State{socket_id: :socket_id}
@@ -217,7 +218,7 @@ defmodule Poxa.WebsocketHandlerTest do
     event = %PusherEvent{channels: ["private-not-subscribed"], name: "client-event"}
     expect(JSX, :decode!, [{[:client_event_json], decoded_json}])
     expect(PusherEvent, :build_client_event, [{[decoded_json, :socket_id], {:ok, event}}])
-    expect(Channel, :subscribed?, 2, false)
+    expect(Channel, :member?, 2, false)
 
     state = %State{socket_id: :socket_id}
 
@@ -290,14 +291,14 @@ defmodule Poxa.WebsocketHandlerTest do
     expect(Channel, :all, 1, :channels)
     expect(Time, :stamp, 0, 100)
     expect(Event, :notify, [{[:disconnected, %{socket_id: :socket_id, channels: :channels, duration: 90}], :ok}])
-    expect(PresenceSubscription, :check_and_remove, 0, :ok)
-    expect(:gproc, :goodbye, 0, :ok)
+    expect(PresenceSubscription, :check_and_remove, 0, 1)
+    expect(Poxa.registry, :clean_up, 0, :ok)
 
     state = %State{socket_id: :socket_id, time: 10}
 
     assert websocket_terminate(:reason, :req, state) == :ok
 
-    assert validate [Event, PresenceSubscription, :gproc]
+    assert validate [Event, PresenceSubscription, Poxa.registry]
   end
 
   test "websocket termination without a socket_id" do


### PR DESCRIPTION
This PR goes in the same direction as #59 and moves gproc code into an adapter. In fact I borrowed some of its code and naming. Thanks a lot for your effort :bow: @joshk. The main change is the use of `Poxa.registry/0` to access the registry. It will find in compile time the configured registry adapter and use it throughout the code. I also took the opportunity to unify very similar code to deal with different types of channels. 

* [x] Move gproc related code to adapter
* [x] Test separately gproc code
* [x] Refactor application and tests to use `Poxa.Registry` behaviour
* [x] Write documentation to new modules
* [x] Refine `@spec`s for new modules