### PR TITLE
refactor run_ssl

### DIFF
--- a/lib/poxa.ex
+++ b/lib/poxa.ex
@@ -63,12 +63,8 @@ defmodule Poxa do
       {:ok, ssl_config} ->
         if Enum.all?([:port, :certfile, :keyfile], &Keyword.has_key?(ssl_config, &1)) do
           ssl_port = Keyword.get(ssl_config, :port)
-          if ssl_port do
-            {:ok, _} = :cowboy.start_https(:https, 100, ssl_config, [env: [dispatch: dispatch] ])
-            Logger.info "Starting Poxa using SSL on port #{ssl_port}"
-          else
-            Logger.info "SSL not configured/started"
-          end
+          {:ok, _} = :cowboy.start_https(:https, 100, ssl_config, [env: [dispatch: dispatch] ])
+          Logger.info "Starting Poxa using SSL on port #{ssl_port}"
         else
           Logger.error "Must specify port, certfile and keyfile (cacertfile optional)"
         end


### PR DESCRIPTION
You don't need to check for the ssl_port again you already have that in place already you can just fetch the `:port` key from the config if the port is not available the above if statement will fail.