### PR TITLE
Reduce Docker image size from 165 MB to 32.8 MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,18 @@ RUN mix deps.get
 RUN mix compile
 RUN echo "" > config/poxa.prod.conf
 RUN mix release
+RUN mkdir -p /app/$APP_NAME
+WORKDIR /app/$APP_NAME
+RUN tar xzf /source/_build/prod/rel/$APP_NAME/releases/0.7.1/$APP_NAME.tar.gz
 
 
-FROM elixir:1.5.2-alpine
+FROM alpine:3.6
 
 ENV APP_NAME poxa
 ENV MIX_ENV prod
 
-RUN apk --no-cache add bash erlang-xmerl erlang-crypto erlang-sasl
+RUN apk --no-cache add bash openssl
 
-COPY --from=builder /source/_build/prod/rel /app
+COPY --from=builder /app /app
 
 CMD /app/$APP_NAME/bin/$APP_NAME foreground

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM elixir:1.5.2-alpine
+FROM elixir:1.5.2-alpine AS builder
 
 ENV APP_NAME poxa
 ENV MIX_ENV prod
 
-RUN apk --update add bash git erlang-xmerl erlang-crypto erlang-sasl && rm -rf /var/cache/apk/*
+RUN apk --no-cache add git erlang-xmerl erlang-crypto erlang-sasl
 
 COPY . /source
 WORKDIR /source
@@ -14,6 +14,14 @@ RUN mix compile
 RUN echo "" > config/poxa.prod.conf
 RUN mix release
 
-RUN mkdir /app && cp -r _build/prod/rel/$APP_NAME /app && rm -rf /source
+
+FROM elixir:1.5.2-alpine
+
+ENV APP_NAME poxa
+ENV MIX_ENV prod
+
+RUN apk --no-cache add bash erlang-xmerl erlang-crypto erlang-sasl
+
+COPY --from=builder /source/_build/prod/rel /app
 
 CMD /app/$APP_NAME/bin/$APP_NAME foreground

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,16 @@ RUN apk --no-cache add git erlang-xmerl erlang-crypto erlang-sasl
 COPY . /source
 WORKDIR /source
 
-RUN mix local.hex --force && mix local.rebar --force
-RUN mix deps.get
-RUN mix compile
+RUN mix do \
+      local.hex --force, \
+      local.rebar --force, \
+      deps.get, \
+      compile
 RUN echo "" > config/poxa.prod.conf
 RUN mix release
 RUN mkdir -p /app/$APP_NAME
 WORKDIR /app/$APP_NAME
-RUN tar xzf /source/_build/prod/rel/$APP_NAME/releases/0.7.1/$APP_NAME.tar.gz
+RUN tar xzf /source/_build/prod/rel/$APP_NAME/releases/*/$APP_NAME.tar.gz
 
 
 FROM alpine:3.6

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -18,7 +18,7 @@ environment :dev do
 end
 
 environment :prod do
-  set include_erts: false
+  set include_erts: true
   set include_src: false
   set cookie: :"xR=}b(ZcHU8M1Lu&642.m{u{O)H]WD>[&&_5t8FW3t5mxy4nw=de~;lEbw*?EFXC"
 end
@@ -30,4 +30,3 @@ release :poxa do
   ]
   plugin Conform.ReleasePlugin
 end
-


### PR DESCRIPTION
I recently upgraded from the old `edgurgelpoxa:0.5.0` docker image to the latest `edgurgel:poxa-automated:0.7.2` docker image, and the image size grew from 26 MB to 165 MB. 

I tried to reduce the size by using multi-stage build available from Docker 17.05 to avoid having any
build artifacts at all and no git package installed. I managed to get a 114 MB image.

I also used `apk --no-cache` instead of `apk --update .... && rm -rf /var/cache/apk/*`.

I do not know Erlang/Elixir well enough to go further but at least it's 50 MB less.