### PR TITLE
Fix WebsocketHandler init to pass proper idle_timeout

### DIFF
--- a/lib/poxa/websocket_handler.ex
+++ b/lib/poxa/websocket_handler.ex
@@ -24,7 +24,10 @@ defmodule Poxa.WebsocketHandler do
   end
 
   @doc false
-  def init(req, _opts), do: {:cowboy_websocket, req, req}
+  def init(req, _opts) do
+    idle_timeout_ms = Application.get_env(:poxa, :activity_timeout) * 1_000
+    {:cowboy_websocket, req, req, %{idle_timeout: idle_timeout_ms}}
+  end
 
   @doc """
   This function checks for proper app_key and protocol before continuing

--- a/test/websocket_handler_test.exs
+++ b/test/websocket_handler_test.exs
@@ -221,6 +221,13 @@ defmodule Poxa.WebsocketHandlerTest do
     assert websocket_handle({:text, :client_event_json}, state) == {:ok, state}
   end
 
+  describe "init/1" do
+    test "sets cowboy's idle_timeout" do
+      :application.set_env(:poxa, :activity_timeout, 30)
+      assert init(:req, []) == {:cowboy_websocket, :req, :req, %{idle_timeout: 30_000}}
+    end
+  end
+
   describe "websocket_init/1" do
     test "websocket init" do
       expect(:cowboy_req, :binding, fn :app_key, :req -> "app_key" end)


### PR DESCRIPTION
It fixes #156 

The idle_timeout was not being set! Now the client will send pings properly if the activity timeout is close